### PR TITLE
Sanitize user input removing all line breaks and whitespaces

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -14,11 +14,17 @@ var Base64DecoderApp = (function () {
             return;
         }
         var decoded = [];
+        encodedMultiPart = Base64DecoderApp.sanitize(encodedMultiPart);
         encodedMultiPart.split(/[^A-Za-z0-9+/=]+/).forEach(function (encodedPart) {
             var decodedPart = Base64DecoderApp.tryJsonDecode(Base64DecoderApp.tryBase64Decode(encodedPart));
             decoded.push(decodedPart);
         });
         this.outputBox.value = decoded.join('\n------------------------------\n');
+    };
+    Base64DecoderApp.sanitize = function (inputStr) {
+        inputStr = inputStr.replace(/\r?\n|\r/g, ''); //  remove all line breaks
+        inputStr = inputStr.replace(/\s/g, ''); //  remove all whitespaces
+        return inputStr;
     };
     Base64DecoderApp.tryBase64Decode = function (inputStr) {
         var result;
@@ -41,5 +47,5 @@ var Base64DecoderApp = (function () {
         return result;
     };
     return Base64DecoderApp;
-})();
+}());
 new Base64DecoderApp('input', 'output');

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,12 +24,21 @@ class Base64DecoderApp {
 
         let decoded: string[] = [];
 
+        encodedMultiPart = Base64DecoderApp.sanitize(encodedMultiPart);
+
         encodedMultiPart.split(/[^A-Za-z0-9+/=]+/).forEach((encodedPart: string) => {
             let decodedPart = Base64DecoderApp.tryJsonDecode(Base64DecoderApp.tryBase64Decode(encodedPart));
             decoded.push(decodedPart);
         });
 
         this.outputBox.value = decoded.join('\n------------------------------\n');
+    }
+
+    private static sanitize(inputStr: string): string {
+        inputStr = inputStr.replace(/\r?\n|\r/g, ''); //  remove all line breaks
+        inputStr = inputStr.replace(/\s/g, ''); //  remove all whitespaces
+
+        return inputStr;
     }
 
     private static tryBase64Decode(inputStr: string): string {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "system",
         "target": "es5",
         "noImplicitAny": false,
         "sourceMap": false,


### PR DESCRIPTION
@luciopaiva there is a minor problem when the input text has line breaks or whitespaces. This PR sanitizes user input removing all line breaks and whitespaces.

It also fixes the following error when running the Typescript compiler:

> error TS6082: Only 'amd' and 'system' modules are supported alongside --out.

There is no bundle format for CommonJS, so it was replaced by the System module format to fix it.

Regards :-)

Bernardo